### PR TITLE
Release for v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 - fix version command by @wreulicke in https://github.com/wreulicke/go-cli-template/pull/2
 - Add gotestsum and test-reporter by @wreulicke in https://github.com/wreulicke/go-cli-template/pull/3
 - migrate by @wreulicke in https://github.com/wreulicke/go-cli-template/pull/4
+- Configure Renovate by @renovate[bot] in https://github.com/wreulicke/go-cli-template/pull/5
+- Update dependency go to v1.25.6 by @renovate[bot] in https://github.com/wreulicke/go-cli-template/pull/8
+- Update module github.com/spf13/cobra to v1.10.2 by @renovate[bot] in https://github.com/wreulicke/go-cli-template/pull/9
+- Update dependency go to v1.25.6 by @renovate[bot] in https://github.com/wreulicke/go-cli-template/pull/12
+
+## [v0.0.3](https://github.com/wreulicke/go-cli-template/compare/v0.0.2...v0.0.3) - 2026-02-02
+- Add patchr comment by @wreulicke in https://github.com/wreulicke/go-cli-template/pull/1
+- fix version command by @wreulicke in https://github.com/wreulicke/go-cli-template/pull/2
+- Add gotestsum and test-reporter by @wreulicke in https://github.com/wreulicke/go-cli-template/pull/3
+- migrate by @wreulicke in https://github.com/wreulicke/go-cli-template/pull/4
 
 ## [v0.0.2](https://github.com/wreulicke/go-cli-template/compare/v0.0.1...v0.0.2) - 2024-07-05
 


### PR DESCRIPTION
This pull request is for the next release as v0.0.3 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.3 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.2" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at master -->

## What's Changed
* Add patchr comment by @wreulicke in https://github.com/wreulicke/go-cli-template/pull/1
* fix version command by @wreulicke in https://github.com/wreulicke/go-cli-template/pull/2
* Add gotestsum and test-reporter by @wreulicke in https://github.com/wreulicke/go-cli-template/pull/3
* migrate by @wreulicke in https://github.com/wreulicke/go-cli-template/pull/4
* Configure Renovate by @renovate[bot] in https://github.com/wreulicke/go-cli-template/pull/5
* Update dependency go to v1.25.6 by @renovate[bot] in https://github.com/wreulicke/go-cli-template/pull/8
* Update module github.com/spf13/cobra to v1.10.2 by @renovate[bot] in https://github.com/wreulicke/go-cli-template/pull/9
* Update dependency go to v1.25.6 by @renovate[bot] in https://github.com/wreulicke/go-cli-template/pull/12

## New Contributors
* @wreulicke made their first contribution in https://github.com/wreulicke/go-cli-template/pull/1
* @renovate[bot] made their first contribution in https://github.com/wreulicke/go-cli-template/pull/5

**Full Changelog**: https://github.com/wreulicke/go-cli-template/compare/v0.0.2...tagpr-from-v0.0.2
<!-- octocov -->
## Code Metrics Report
|                         | [master](https://github.com/wreulicke/go-cli-template/tree/master) ([44a0707](https://github.com/wreulicke/go-cli-template/commit/44a07074d0df349013e7c1294491fd16c964b408)) | [#7](https://github.com/wreulicke/go-cli-template/pull/7) ([52af8d3](https://github.com/wreulicke/go-cli-template/commit/52af8d325a1772da53fc0317f21cbe100d2b0f0f)) | +/-  |
|-------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|--------------------------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage**            |                                                                                                                                                                        37.0% |                                                                                                                                                               37.0% | 0.0% |
| **Code to Test Ratio**  |                                                                                                                                                                        1:0.1 |                                                                                                                                                               1:0.1 |  0.0 |
| **Test Execution Time** |                                                                                                                                                                           4s |                                                                                                                                                                  3s |  -1s |

<details>

<summary>Details</summary>

``` diff
  |                     | master (44a0707) | #7 (52af8d3) | +/-  |
  |---------------------|------------------|--------------|------|
  | Coverage            |            37.0% |        37.0% | 0.0% |
  |   Files             |                1 |            1 |    0 |
  |   Lines             |               27 |           27 |    0 |
  |   Covered           |               10 |           10 |    0 |
  | Code to Test Ratio  |            1:0.1 |        1:0.1 |  0.0 |
  |   Code              |               62 |           62 |    0 |
  |   Test              |                9 |            9 |    0 |
+ | Test Execution Time |               4s |           3s |  -1s |
```

</details>



---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
